### PR TITLE
private def closure causes MissingMethodException #11

### DIFF
--- a/GrailsMelodyGrailsPlugin.groovy
+++ b/GrailsMelodyGrailsPlugin.groovy
@@ -140,7 +140,7 @@ class GrailsMelodyGrailsPlugin {
 							break
 						}
 					}
-					if(!found && delegate.metaClass.properties.find {it.name == name}){
+					if(!found && delegate."${name}"){
 						def property = delegate."${name}"
 						if(property instanceof Closure){
 							found = true


### PR DESCRIPTION
This will avoid MissingMethodException if called closure defined as 'private'.
