### PR TITLE
Getting the disabled property from the grails javamelody config instead ...

### DIFF
--- a/GrailsMelodyGrailsPlugin.groovy
+++ b/GrailsMelodyGrailsPlugin.groovy
@@ -2,8 +2,6 @@ import grails.plugin.melody.GrailsMelodyUtil
 import net.bull.javamelody.JdbcWrapper
 import net.bull.javamelody.MonitoringFilter
 import net.bull.javamelody.MonitoringProxy
-import net.bull.javamelody.Parameter
-import net.bull.javamelody.Parameters
 import net.bull.javamelody.SessionListener
 import javax.sql.DataSource
 
@@ -124,7 +122,7 @@ class GrailsMelodyGrailsPlugin {
 		//to 'intercept' method call and collect infomation for monitoring purpose.
 		//The code below mimics 'MonitoringSpringInterceptor.invoke()'
 		def SPRING_COUNTER = MonitoringProxy.getSpringCounter()
-		final boolean DISABLED = Boolean.parseBoolean(Parameters.getParameter(Parameter.DISABLED))
+		final boolean DISABLED = GrailsMelodyUtil.getGrailsMelodyConfig(application)?.javamelody?.disabled
 
 		if (DISABLED || !SPRING_COUNTER.isDisplayed()) {
 			return


### PR DESCRIPTION
...of using the Parameters class from javamelody. The last option doesn't work when running test-app because there is no servletContext and therefore the Parameters.getParameter(...) returns null.
